### PR TITLE
feat(HACBS-1728): implement appropriate metrics for the Internal Service controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY loader/ loader/
+COPY metrics/ metrics/
 COPY tekton/ tekton/
 
 # Build

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -22,7 +22,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../monitoring
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/monitoring/kustomization.yaml
+++ b/config/monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: grafana-operator-system
+generatorOptions:
+  disableNameSuffixHash: true
+resources:
+  - prometheus/monitor.yaml

--- a/config/monitoring/prometheus/monitor.yaml
+++ b/config/monitoring/prometheus/monitor.yaml
@@ -1,0 +1,20 @@
+
+# Prometheus Monitor Service (Metrics)
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: controller-manager-metrics-monitor
+  namespace: system
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -18,6 +18,8 @@ package internalrequest
 
 import (
 	"fmt"
+	"reflect"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	libhandler "github.com/operator-framework/operator-lib/handler"
@@ -27,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -96,6 +97,7 @@ var _ = Describe("PipelineRun", Ordered, func() {
 					Err:        fmt.Errorf("not found"),
 				},
 			})
+			adapter.internalRequest.MarkRunning()
 
 			result, err := adapter.EnsurePipelineExists()
 			Expect(result.CancelRequest && !result.RequeueRequest).To(BeTrue())
@@ -161,8 +163,8 @@ var _ = Describe("PipelineRun", Ordered, func() {
 					Err:        fmt.Errorf("not found"),
 				},
 			})
+			adapter.internalRequest.MarkRunning()
 			adapter.internalRequest.MarkSucceeded()
-
 			result, err := adapter.EnsurePipelineRunIsDeleted()
 			Expect(!result.CancelRequest && result.RequeueRequest).To(BeTrue())
 			Expect(err).NotTo(BeNil())
@@ -376,6 +378,7 @@ var _ = Describe("PipelineRun", Ordered, func() {
 		})
 
 		It("should set the InternalRequest as succeeded if the PipelineRun succeeded", func() {
+			adapter.internalRequest.MarkRunning()
 			pipelineRun := &tektonv1beta1.PipelineRun{}
 			pipelineRun.Status.MarkSucceeded("", "")
 			Expect(adapter.registerInternalRequestPipelineRunStatus(pipelineRun)).To(BeNil())
@@ -383,6 +386,7 @@ var _ = Describe("PipelineRun", Ordered, func() {
 		})
 
 		It("should set the InternalRequest as failed if the PipelineRun failed", func() {
+			adapter.internalRequest.MarkRunning()
 			pipelineRun := &tektonv1beta1.PipelineRun{}
 			pipelineRun.Status.MarkFailed("", "")
 			Expect(adapter.registerInternalRequestPipelineRunStatus(pipelineRun)).To(BeNil())

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.5.0
 	github.com/onsi/gomega v1.24.1
 	github.com/operator-framework/operator-lib v0.11.0
+	github.com/prometheus/client_golang v1.13.0
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20230113090719-a8a43f600367
 	github.com/tektoncd/pipeline v0.42.0
 	k8s.io/api v0.25.4
@@ -63,7 +64,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/metrics/internalrequest.go
+++ b/metrics/internalrequest.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	InternalRequestAttemptConcurrentTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "internal_request_attempt_concurrent_requests",
+			Help: "Total number of concurrent InternalRequest attempts",
+		},
+	)
+
+	InternalRequestAttemptDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "internal_request_attempt_duration_seconds",
+			Help:    "Time from the moment the InternalRequest starts being processed until it completes",
+			Buckets: []float64{10, 20, 40, 60, 150, 300, 450, 900, 1800, 3600},
+		},
+		[]string{"request", "namespace", "reason", "succeeded"},
+	)
+
+	InternalRequestAttemptTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "internal_request_attempt_total",
+			Help: "Total number of InternalRequests processed by the operator",
+		},
+		[]string{"request", "namespace", "reason", "succeeded"},
+	)
+)
+
+// RegisterCompletedInternalRequest decrements the 'internal_request_attempt_concurrent_total' metric, increments `internal_request_attempt_total`
+// and registers a new observation for 'internal_request_attempt_duration_seconds' with the elapsed time from the moment the
+// InternalRequest attempt started (InternalRequest marked as 'Running').
+func RegisterCompletedInternalRequest(request, namespace, reason string, startTime, completionTime *metav1.Time, succeeded bool) {
+	labels := prometheus.Labels{
+		"request":   request,
+		"namespace": namespace,
+		"reason":    reason,
+		"succeeded": strconv.FormatBool(succeeded),
+	}
+	InternalRequestAttemptConcurrentTotal.Dec()
+	InternalRequestAttemptDurationSeconds.With(labels).Observe(completionTime.Sub(startTime.Time).Seconds())
+	InternalRequestAttemptTotal.With(labels).Inc()
+}
+
+// RegisterNewInternalRequest increments the number of the 'internal_request_attempt_concurrent_total' metric which represents the number of concurrent running InternalRequests.
+func RegisterNewInternalRequest(creationTime metav1.Time, startTime *metav1.Time) {
+	InternalRequestAttemptConcurrentTotal.Inc()
+}
+
+func init() {
+	metrics.Registry.MustRegister(
+		InternalRequestAttemptConcurrentTotal,
+		InternalRequestAttemptDurationSeconds,
+		InternalRequestAttemptTotal,
+	)
+}

--- a/metrics/internalrequest_suite_test.go
+++ b/metrics/internalrequest_suite_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type inputHeader struct {
+	Name string
+	Help string
+}
+
+func TestMetricsRelease(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Release Test Suite")
+}
+
+var (
+	testEnv *envtest.Environment
+	ctx     context.Context
+	cancel  context.CancelFunc
+)
+
+var _ = BeforeSuite(func() {
+	ctx, cancel = context.WithCancel(context.TODO())
+	testEnv = &envtest.Environment{}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
+		MetricsBindAddress: ":8081",
+		LeaderElection:     false,
+	})
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// createCounterReader creates a prometheus counter type string with the given parameters to be used as input data
+// for 'strings.NewReader' in Prometheus 'client_golang' function 'testutil.CollectAndCompare'.
+func createCounterReader(header inputHeader, labels string, renderHeader bool, count int) string {
+	readerData := ""
+	if renderHeader {
+		readerData = fmt.Sprintf("# HELP %s %s\n# TYPE %s counter\n", header.Name, header.Help, header.Name)
+	}
+	readerData += fmt.Sprintf("%s{%s} %d\n", header.Name, labels, count)
+
+	return readerData
+}
+
+// createHistogramReader creates a prometheus histogram type string with the given parameters to be used as input data
+// for 'strings.NewReader' in Prometheus 'client_golang' function 'testutil.CollectAndCompare'.
+func createHistogramReader(header inputHeader, timeBuckets []string, bucketsData []int, labels string, sum float64, count int) string {
+	readerData := fmt.Sprintf("# HELP %s %s\n# TYPE %s histogram\n", header.Name, header.Help, header.Name)
+	for i, bucket := range timeBuckets {
+		readerData += fmt.Sprintf("%s_bucket{%sle=\"%s\"} %d\n", header.Name, labels, bucket, bucketsData[i])
+	}
+
+	if labels != "" {
+		readerData += fmt.Sprintf("%s_sum{%s} %f\n\n", header.Name, labels, sum)
+		readerData += fmt.Sprintf("%s_count{%s} %d\n", header.Name, labels, count)
+	} else {
+		readerData += fmt.Sprintf("%s_sum %f\n%s_count %d\n", header.Name, sum, header.Name, count)
+	}
+
+	return readerData
+}

--- a/metrics/internalrequest_test.go
+++ b/metrics/internalrequest_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var _ = Describe("Metrics InternalRequest", Ordered, func() {
+	BeforeAll(func() {
+
+		// We need to unregister in advance otherwise it breaks with 'AlreadyRegisteredError'
+		metrics.Registry.Unregister(InternalRequestAttemptConcurrentTotal)
+		metrics.Registry.Unregister(InternalRequestAttemptDurationSeconds)
+	})
+
+	var (
+		attemptDurationSecondsHeader = inputHeader{
+			Name: "internal_request_attempt_duration_seconds",
+			Help: "Time from the moment the InternalRequest starts being processed until it completes",
+		}
+		attemptTotalHeader = inputHeader{
+			Name: "internal_request_attempt_total",
+			Help: "Total number of InternalRequests processed by the operator",
+		}
+	)
+
+	const (
+		defaultNamespace             = "default"
+		validInternalRequestReason   = "valid_internalrequest_reason"
+		invalidInternalRequestReason = "invalid_internalrequest_reason"
+		strategy                     = "nostrategy"
+	)
+
+	Context("When RegisterCompletedInternalRequest is called", func() {
+		BeforeAll(func() {
+			InternalRequestAttemptDurationSeconds = prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Name:    "internal_request_attempt_duration_seconds",
+					Help:    "Time from the moment the InternalRequest starts being processed until it completes",
+					Buckets: []float64{60, 600, 1800, 3600},
+				},
+				[]string{"request", "namespace", "reason", "succeeded"},
+			)
+
+			InternalRequestAttemptConcurrentTotal = prometheus.NewGauge(
+				prometheus.GaugeOpts{
+					Name: "internal_request_attempt_concurrent_requests",
+					Help: "Total number of concurrent InternalRequest attempts",
+				},
+			)
+			metrics.Registry.MustRegister(InternalRequestAttemptDurationSeconds, InternalRequestAttemptConcurrentTotal)
+		})
+
+		AfterAll(func() {
+			metrics.Registry.Unregister(InternalRequestAttemptDurationSeconds)
+			metrics.Registry.Unregister(InternalRequestAttemptConcurrentTotal)
+		})
+
+		// Input seconds for duration of operations less or equal to the following buckets of 60, 600, 1800 and 3600 seconds
+		inputSeconds := []float64{30, 500, 1500, 3000}
+		elapsedSeconds := 0.0
+		labels := fmt.Sprintf(`namespace="%s", reason="%s", request="%s", succeeded="true",`,
+			defaultNamespace, validInternalRequestReason, "iib")
+
+		It("increments 'InternalRequestAttemptConcurrentTotal' so we can decrement it to a non-negative number in the next test", func() {
+			creationTime := metav1.Time{}
+			for _, seconds := range inputSeconds {
+				startTime := metav1.NewTime(creationTime.Add(time.Second * time.Duration(seconds)))
+				RegisterNewInternalRequest(creationTime, &startTime)
+			}
+			Expect(testutil.ToFloat64(InternalRequestAttemptConcurrentTotal)).To(Equal(float64(len(inputSeconds))))
+		})
+
+		It("increments 'InternalRequestAttemptTotal' and decrements 'InternalRequestAttemptConcurrentTotal'", func() {
+			completionTime := metav1.Time{}
+			for _, seconds := range inputSeconds {
+				completionTime := metav1.NewTime(completionTime.Add(time.Second * time.Duration(seconds)))
+				elapsedSeconds += seconds
+				RegisterCompletedInternalRequest("iib", defaultNamespace, validInternalRequestReason, &metav1.Time{}, &completionTime, true)
+			}
+			readerData := createCounterReader(attemptTotalHeader, labels, true, len(inputSeconds))
+			Expect(testutil.ToFloat64(InternalRequestAttemptConcurrentTotal)).To(Equal(0.0))
+			Expect(testutil.CollectAndCompare(InternalRequestAttemptTotal, strings.NewReader(readerData))).To(Succeed())
+		})
+
+		It("registers a new observation for 'InternalRequestAttemptDurationSeconds' with the elapsed time from the moment the InternalRequest attempt started (InternalRequest marked as 'Running').", func() {
+			timeBuckets := []string{"60", "600", "1800", "3600"}
+			// For each time bucket how many InternalRequests completed below 4 seconds
+			data := []int{1, 2, 3, 4}
+			readerData := createHistogramReader(attemptDurationSecondsHeader, timeBuckets, data, labels, elapsedSeconds, len(inputSeconds))
+			Expect(testutil.CollectAndCompare(InternalRequestAttemptDurationSeconds, strings.NewReader(readerData))).To(Succeed())
+		})
+	})
+
+})


### PR DESCRIPTION
feat(HACBS-1728): implement metrics for the Internal Service controller
    
- adds metrics for internal-services-controller
- update go.mod
- adds tests for /metrics
    
Signed-off-by: Leandro Mendes <lmendes@redhat.com>
