### PR TITLE
fix(HACBS-1763): get sha from github variable

### DIFF
--- a/.github/workflows/app_interface.yaml
+++ b/.github/workflows/app_interface.yaml
@@ -47,7 +47,7 @@ jobs:
         working-directory: app-interface-deployments/internal-services
       - name: Update image
         run: |
-          sed -i 's/image: controller:latest/image: quay.io\/redhat-appstudio\/internal-services:${{ github.event.pull_request.head.sha }}/' manager.yaml
+          sed -i 's/image: controller:latest/image: quay.io\/redhat-appstudio\/internal-services:${{ github.sha }}/' manager.yaml
         working-directory: app-interface-deployments/internal-services/manager
       - name: Add users to role binding
         run: |


### PR DESCRIPTION
The variable used to get the SHA was not present when running the workflow as part of a push to main.


Signed-off-by: David Moreno García <damoreno@redhat.com>