### PR TITLE
fix(HACBS-1727): increase memory for controller

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,10 +81,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 512Mi
         env:
           - name: SERVICE_NAMESPACE
             valueFrom:


### PR DESCRIPTION
- appSRE production cluster requires 512m for startup