### PR TITLE
chore(STONEBLD-777): update tekton-ci bundle

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -17,7 +17,7 @@ spec:
       value: 'quay.io/redhat-appstudio/pull-request-builds:internal-services-{{ revision }}'
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -15,13 +15,9 @@ spec:
       value: "{{ revision }}"
     - name: output-image
       value: 'quay.io/redhat-appstudio/internal-services:{{ revision }}'
-    - name: path-context
-      value: .
-    - name: dockerfile
-      value: Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
Switching to new bundle since development of old one was stopped before attempt to migrate to kcp. New bundle is removing dependency on shared secret.