### PR TITLE
feat(KFLUXBUGS-1162): support override of election leaderId

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240317073005-bd9ea79e8d18
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var enableLeaderElectionId string
 	var probeAddr string
 	var remoteClusterConfigFile string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -70,6 +71,9 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&enableLeaderElectionId, "leader-election-id",
+		"b548bb9d.redhat.com",
+		"Enable overriding leader election ID for controller manager. ")
 	flag.StringVar(&remoteClusterConfigFile, "remote-cluster-config-file", "",
 		"The remote client will load its initial configuration from this file. "+
 			"Omit this flag to use the default configuration values. "+
@@ -89,7 +93,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "b548bb9d.redhat.com",
+		LeaderElectionID:       enableLeaderElectionId,
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
 				&tektonv1beta1.PipelineRun{}: {


### PR DESCRIPTION
- allows us to have multiple controllers pointing to different Konflux instances.

**default instance of ISC**

> I0319 00:27:55.827903 1 leaderelection.go:248] attempting to acquire leader lease stonesoup-int-srvc/b548bb9d.redhat.com...
> I0319 00:34:28.722321 1 leaderelection.go:258] successfully acquired lease stonesoup-int-srvc/b548bb9d.redhat.com

**when using the new argument**

> I0319 01:29:40.951121 1 leaderelection.go:248] attempting to acquire leader lease stonesoup-int-srvc/staging-p01...
> I0319 01:29:40.963978 1 leaderelection.go:258] successfully acquired lease stonesoup-int-srvc/staging-p01

**pipeline execution logs from p01**

> 2024-03-19T01:47:20.603Z INFO controllers.internalRequest Created PipelineRun to handle request {"InternalRequest": "rhtap-releng-tenant-tenant/myrequest", "PipelineRun.Name": "internalrequest-k6glc", "PipelineRun.Namespace": "stonesoup-int-srvc"}
> 2024-03-19T01:47:20.694Z INFO controllers.internalRequest Request execution finished {"InternalRequest": "rhtap-releng-tenant-tenant/myrequest", "Succeeded": false}
> 2024-03-19T01:47:20.694Z INFO controllers.internalRequest Running in debug mode. Skipping PipelineRun deletion {"InternalRequest": "rhtap-releng-tenant-tenant/myrequest"}

**2 pods running**

![Screenshot from 2024-03-18 21-57-30](https://github.com/redhat-appstudio/internal-services/assets/3596711/ba94ed0c-73ab-41b4-a0f9-00cdb8a785e3)

**new setup of manager deployments**

![Screenshot from 2024-03-18 21-59-36](https://github.com/redhat-appstudio/internal-services/assets/3596711/37ae4a3f-c0f3-43b3-92c1-b7281f9c70b5)

**specification of staging directory in app-interface**

![Screenshot from 2024-03-18 22-01-42](https://github.com/redhat-appstudio/internal-services/assets/3596711/0eafdfef-e2f7-4feb-888b-367ece7b3704)
