### PR TITLE
feat(RHTAPREL-806): update operator toolkit reference

### DIFF
--- a/api/v1alpha1/internalrequest_conditions.go
+++ b/api/v1alpha1/internalrequest_conditions.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
-import "github.com/redhat-appstudio/operator-toolkit/conditions"
+import "github.com/konflux-ci/operator-toolkit/conditions"
 
 const (
 	// SucceededConditionType is the type used when setting a status condition

--- a/api/v1alpha1/internalrequest_types.go
+++ b/api/v1alpha1/internalrequest_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/redhat-appstudio/operator-toolkit/conditions"
 	"time"
+
+	"github.com/konflux-ci/operator-toolkit/conditions"
 
 	"github.com/redhat-appstudio/internal-services/metrics"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/api/v1alpha1/internalrequest_types_test.go
+++ b/api/v1alpha1/internalrequest_types_test.go
@@ -8,7 +8,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/redhat-appstudio/operator-toolkit/conditions"
+	"github.com/konflux-ci/operator-toolkit/conditions"
 )
 
 var _ = Describe("Internal Request type", func() {

--- a/controllers/controllers.go
+++ b/controllers/controllers.go
@@ -17,8 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"github.com/redhat-appstudio/internal-services/controllers/internalrequest"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
 )
 
 var EnabledControllers = []controller.Controller{

--- a/controllers/internalrequest/adapter.go
+++ b/controllers/internalrequest/adapter.go
@@ -19,16 +19,17 @@ package internalrequest
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/go-logr/logr"
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
 	"github.com/redhat-appstudio/internal-services/loader"
 	"github.com/redhat-appstudio/internal-services/tekton"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/controllers/internalrequest/adapter_test.go
+++ b/controllers/internalrequest/adapter_test.go
@@ -18,8 +18,9 @@ package internalrequest
 
 import (
 	"fmt"
+
+	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	"github.com/redhat-appstudio/internal-services/loader"
-	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 
 	"reflect"
 

--- a/controllers/internalrequest/controller.go
+++ b/controllers/internalrequest/controller.go
@@ -18,13 +18,14 @@ package internalrequest
 
 import (
 	"context"
+
 	"github.com/go-logr/logr"
+	"github.com/konflux-ci/operator-toolkit/controller"
+	"github.com/konflux-ci/operator-toolkit/predicates"
 	libhandler "github.com/operator-framework/operator-lib/handler"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
 	"github.com/redhat-appstudio/internal-services/loader"
 	"github.com/redhat-appstudio/internal-services/tekton"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
-	"github.com/redhat-appstudio/operator-toolkit/predicates"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/controllers/internalrequest/internalrequest_suite_test.go
+++ b/controllers/internalrequest/internalrequest_suite_test.go
@@ -18,13 +18,14 @@ package internalrequest
 
 import (
 	"context"
-	appstudiov1alpha1 "github.com/redhat-appstudio/internal-services/api/v1alpha1"
-	"github.com/redhat-appstudio/operator-toolkit/test"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go/build"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
+
+	"github.com/konflux-ci/operator-toolkit/test"
+	appstudiov1alpha1 "github.com/redhat-appstudio/internal-services/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.3
+	github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d
 	github.com/onsi/ginkgo/v2 v2.6.0
 	github.com/onsi/gomega v1.24.1
 	github.com/operator-framework/operator-lib v0.11.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed
 	github.com/tektoncd/pipeline v0.42.0
 	go.uber.org/zap v1.24.0
 	k8s.io/api v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d h1:z7j3mglNoXvIrw5Vz/Ul+izoITRaqYURPIWrFoEyHgI=
+github.com/konflux-ci/operator-toolkit v0.0.0-20240402130556-ef6dcbeca69d/go.mod h1:AcChx7FjpYSIkDvQgaUKyauuF0PXm3ivB5MqZSC9Eis=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -298,8 +300,6 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
 github.com/prometheus/statsd_exporter v0.22.8 h1:Qo2D9ZzaQG+id9i5NYNGmbf1aa/KxKbB9aKfMS+Yib0=
 github.com/prometheus/statsd_exporter v0.22.8/go.mod h1:/DzwbTEaFTE0Ojz5PqcSk6+PFHOPWGxdXVr6yC8eFOM=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed h1:4RQmIIyZPm7dZuwtPUvbTLQCNIkUR13zLIVlUE9nunA=
-github.com/redhat-appstudio/operator-toolkit v0.0.0-20230705141436-de654b7a7aed/go.mod h1:6lVK58G/zkoxMoHAmYxzF6La8rMmCeZwOQk6i0dpYZo=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -2,9 +2,10 @@ package loader
 
 import (
 	"context"
+
+	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
 	"github.com/redhat-appstudio/internal-services/tekton"
-	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -2,8 +2,9 @@ package loader
 
 import (
 	"context"
+
+	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
-	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -1,10 +1,10 @@
 package loader
 
 import (
+	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redhat-appstudio/internal-services/api/v1alpha1"
-	toolkit "github.com/redhat-appstudio/operator-toolkit/loader"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 

--- a/loader/loader_suite_test.go
+++ b/loader/loader_suite_test.go
@@ -18,13 +18,14 @@ package loader
 
 import (
 	"context"
-	appstudiov1alpha1 "github.com/redhat-appstudio/internal-services/api/v1alpha1"
-	"github.com/redhat-appstudio/operator-toolkit/test"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go/build"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"testing"
+
+	"github.com/konflux-ci/operator-toolkit/test"
+	appstudiov1alpha1 "github.com/redhat-appstudio/internal-services/api/v1alpha1"
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/main.go
+++ b/main.go
@@ -18,16 +18,19 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/redhat-appstudio/internal-services/metadata"
 	"github.com/redhat-appstudio/internal-services/tekton"
-	"github.com/redhat-appstudio/operator-toolkit/controller"
-	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+	"github.com/konflux-ci/operator-toolkit/controller"
 	"go.uber.org/zap/zapcore"
+
+	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/manager"

--- a/tekton/tekton_suite_test.go
+++ b/tekton/tekton_suite_test.go
@@ -18,10 +18,11 @@ package tekton
 
 import (
 	"context"
-	"github.com/redhat-appstudio/operator-toolkit/test"
 	"go/build"
 	"path/filepath"
 	"testing"
+
+	"github.com/konflux-ci/operator-toolkit/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
This commit updates the `operator-toolkit` refrence as result of migration to `konflux-ci` from `redhat-appstudio` more details parent EPIC:
https://issues.redhat.com/browse/RHTAPREL-800